### PR TITLE
Initial user management flows

### DIFF
--- a/app/data.js
+++ b/app/data.js
@@ -1,5 +1,6 @@
 import logs from './data/logs.js'
 import questions from './data/questions.js'
+import users from './data/users.js'
 
 export default async () => ({
   logs,
@@ -19,5 +20,6 @@ export default async () => ({
     id: 'submission',
     title: 'Submission'
   }],
-  questions: await questions()
+  questions: await questions(),
+  users
 })

--- a/app/data/users.js
+++ b/app/data/users.js
@@ -1,0 +1,22 @@
+export default {
+  EXDC1: {
+    name: 'Delia Cross',
+    email: 'delia.cross@example.gov.uk',
+    role: 'coordinator',
+    lastActive: '2021-10-24T16:04:34',
+    invitedBy: 'Janina Doe'
+  },
+  EXDP1: {
+    name: 'Daisy Perkins',
+    email: 'daisy.perkins@example.gov.uk',
+    role: 'provider',
+    invitedBy: 'Delia Cross'
+  },
+  EXDP2: {
+    name: 'Michael Smith',
+    email: 'm.smith@charity.org.uk',
+    role: 'provider',
+    lastActive: '2021-08-09T12:24:12',
+    invitedBy: 'Delia Cross'
+  }
+}

--- a/app/layouts/base.njk
+++ b/app/layouts/base.njk
@@ -44,13 +44,18 @@
   {{- serviceName + " - GOV.UK" -}}
 {% endblock %}
 
+{% set canManageUsers = data.account.role == "coordinator" %}
+
 {% block header %}
   {{ govukHeader({
     homepageUrl: "/",
     serviceName: serviceName,
-    serviceUrl: "/logs"  if data.account else "/",
+    serviceUrl: "/logs"  if data.account.token else "/",
     containerClasses: "govuk-width-container",
     navigation: [{
+      href: "/users/",
+      text: "Users"
+    } if canManageUsers, {
       href: "/account/",
       text: "Your account"
     }, {

--- a/app/views/account/create-account.njk
+++ b/app/views/account/create-account.njk
@@ -1,6 +1,6 @@
 {% extends "form.njk" %}
 
-{% set title = "Create a CORE account" %}
+{% set title = "Create an account to submit CORE data" %}
 {% set formAction = "/logs" %}
 
 {% block form %}
@@ -8,16 +8,16 @@
     <div class="govuk-grid-column-two-thirds">
       {{ macro.heading(title) }}
 
-      <p>You have been invited to create a CORE account with the email address <strong>jane.doe@walford.gov.uk</strong>.</p>
+      <p>You have been invited to create an account with the email address <strong>jane.doe@example.gov.uk</strong>.</p>
 
       {{ govukInput(decorate({
         type: "hidden",
-        value: "Jane Doe"
+        value: "Janina Doe"
       }, ["account", "name"])) }}
 
       {{ govukInput(decorate({
         type: "hidden",
-        value: "jane.doe@walford.gov.uk"
+        value: "janina.doe@example.gov.uk"
       }, ["account", "email"])) }}
 
       {{ govukInput({

--- a/app/views/account/index.njk
+++ b/app/views/account/index.njk
@@ -36,7 +36,7 @@
               href: "/account/personal-details?referrer=" + referrer,
               text: "Change",
               visuallyHiddenText: "email address"
-            }]
+            } if canManageUsers]
           }
         }, {
           key: {
@@ -51,6 +51,20 @@
               text: "Change",
               visuallyHiddenText: "password"
             }]
+          }
+        }, {
+          key: {
+            text: "Role"
+          },
+          value: {
+            text: "Data " + account.role
+          },
+          actions: {
+            items: [{
+              href: "#",
+              text: "Change",
+              visuallyHiddenText: "role"
+            } if canManageUsers]
           }
         }]
       }) }}

--- a/app/views/account/personal-details.njk
+++ b/app/views/account/personal-details.njk
@@ -23,7 +23,7 @@
         },
         autocomplete: "email",
         spellcheck: false
-      }, ["account", "email"])) }}
+      }, ["account", "email"])) if canManageUsers }}
 
       {{ govukButton({
         text: "Save changes"

--- a/app/views/account/reset-password.njk
+++ b/app/views/account/reset-password.njk
@@ -1,7 +1,6 @@
 {% extends "form.njk" %}
 
 {% set title = "Reset your password" %}
-{% set formAction = "/account/sign-in?success=password-reset" %}
 
 {% block form %}
   <div class="govuk-grid-row">

--- a/app/views/account/sign-in.njk
+++ b/app/views/account/sign-in.njk
@@ -1,13 +1,12 @@
 {% extends "form.njk" %}
 
 {% set title = "Sign in to your account to submit CORE data" %}
-{% set formAction = "/logs" %}
 
 {% block form %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {{ govukNotificationBanner({
-        html: "Your password has been reset. Sign in with your new password to continue.",
+        text: "Your password has been reset. Sign in with your new password to continue.",
         type: "success"
       }) if success == "password-reset" }}
 
@@ -30,11 +29,6 @@
         autocomplete: "current-password",
         spellcheck: false
       }) }}
-
-      {{ govukInput(decorate({
-        type: "hidden",
-        value: "true"
-      }, ["account", "token"])) }}
 
       {{ govukButton({
         text: "Sign in"

--- a/app/views/macros.njk
+++ b/app/views/macros.njk
@@ -1,6 +1,30 @@
+{# Common macros #}
 {% macro heading(heading, caption, size="l", headingLevel="1") %}
 <h{{ headingLevel }} class="govuk-heading-{{ size }}">
   {% if caption %}<span class="govuk-caption-{{ size }}">{{ caption }}</span>{% endif %}
   {{ heading }}
 </h{{ headingLevel }}>
+{% endmacro %}
+
+{% macro notificationBannerText(success, object) %}
+  {{ (object + " has been invited to submit CORE data.") if success == "invited" }}
+  {{ (object + " has been deactivated.") if success == "deactivated" }}
+  {{ ("An invitation to submit CORE data has been resent to " + object + ".") if success == "reinvited" }}
+{% endmacro %}
+
+{# User macros #}
+{% macro userNameHtml(id, user) %}
+  <a href="/users/{{ id }}">{{ user.name }}</a><br>
+  <span class="govuk-!-font-weight-regular">{{ user.email }}</span>
+{% endmacro %}
+
+{% macro userLastActiveHtml(id, user) %}
+  {% if user.deactivated %}
+    <span class="app-!-colour-muted">Deactivated</span>
+  {% elif user.lastActive %}
+    {{ user.lastActive | govukDate }}
+  {% else %}
+    Invited by {{ user.invitedBy or "Janina Doe" }}<br>
+    <a href="/users?success=reinvited&#38;userId={{ id }}">Resend invitation email</a>
+  {% endif %}
 {% endmacro %}

--- a/app/views/users/deactivate.njk
+++ b/app/views/users/deactivate.njk
@@ -1,0 +1,21 @@
+{% extends "form.njk" %}
+
+{% set title = "Are you sure you want to deactive this user?" | noOrphans | safe %}
+{% set backLink = userPath %}
+
+{% block form %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ macro.heading(title, user.name) }}
+
+      <p>Deactivating this user will mean they can no longer access this service to submit CORE data.</p>
+      <p>Any logs this user has already submitted will not be affected.</p>
+
+      {{ govukButton({
+        classes: "govuk-button--warning",
+        text: "I’m sure – I do want to deactivate this user"
+      }) }}
+      <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="/users">No - I’ve changed my mind</a></p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/users/index.njk
+++ b/app/views/users/index.njk
@@ -1,0 +1,45 @@
+{% extends "base.njk" %}
+
+{% import "macros.njk" as macro %}
+
+{% set title = "Users" %}
+
+{% block content %}
+  {{ govukNotificationBanner({
+    text: macro.notificationBannerText(success, users[userId].name),
+    type: "success"
+  }) if success }}
+
+  {{ macro.heading(title) }}
+
+  {{ govukButton({
+    href: "/users/new",
+    text: "Invite user"
+  }) }}
+
+  {%- set userRows = [] -%}
+  {% for id, user in users %}
+    {% if user.email != account.email %}
+      {% set row = userRows.push([{
+          html: macro.userNameHtml(id, user)
+        }, {
+          text: "Data " + user.role
+        }, {
+          text: macro.userLastActiveHtml(id, user)
+        }])
+      %}
+    {% endif %}
+  {% endfor %}
+
+  {{ govukTable({
+    firstCellIsHeader: true,
+    head: [{
+      text: "Name and email address"
+    }, {
+      text: "Role"
+    }, {
+      text: "Last logged in"
+    }],
+    rows: userRows
+  }) }}
+{% endblock %}

--- a/app/views/users/personal-details.njk
+++ b/app/views/users/personal-details.njk
@@ -1,0 +1,52 @@
+{% extends "form.njk" %}
+
+{% if user.name and user.email %}
+  {# Editing an existing user #}
+  {% set caption = user.name %}
+  {% set title = "Personal details" %}
+  {% set buttonText = "Save changes" %}
+  {% set backLink = userPath %}
+  {% set formAction = userPath %}
+{% else %}
+  {# Inviting a new user #}
+  {% set caption = false %}
+  {% set title = "Invite a user to submit CORE data" %}
+  {% set buttonText = "Continue" %}
+  {% set backLink = "/users" %}
+  {% set formAction = userPath + "/role" %}
+{% endif %}
+
+{% block form %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ macro.heading(title, caption) }}
+
+      {{ govukInput(decorate({
+        label: {
+          text: "Name"
+        },
+        autocomplete: "name",
+        spellcheck: false
+      }, ["users", user.id, "name"])) }}
+
+      {{ govukInput(decorate({
+        label: {
+          text: "Email address"
+        },
+        autocomplete: "email",
+        spellcheck: false
+      }, ["users", user.id, "email"])) }}
+
+      {% if not user.invitedBy %}
+        {{ govukInput(decorate({
+          type: "hidden",
+          value: account.name
+        }, ["users", user.id, "invitedBy"])) }}
+      {% endif %}
+
+      {{ govukButton({
+        text: buttonText
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/users/role.njk
+++ b/app/views/users/role.njk
@@ -1,0 +1,64 @@
+{% extends "form.njk" %}
+
+{% set title = "What is this user’s role?" %}
+{% if user.role %}
+  {# Editing an existing user #}
+  {% set buttonText = "Save changes" %}
+  {% set backLink = userPath %}
+  {% set formAction = userPath %}
+{% else %}
+  {# Inviting a new user #}
+  {% set buttonText = "Send invitation" %}
+  {% set backLink = userPath + "/personal-details" %}
+  {% set formAction = "/users?success=invited&userId=" + user.id %}
+{% endif %}
+
+{% block form %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% set dataProviderPermissionsHintHtml %}
+        <ul class="govuk-list govuk-list--bullet govuk-hint">
+          <li>Can view and submit logs</li>
+        </ul>
+      {% endset %}
+
+      {% set dataCoordinatorPermissionsHintHtml %}
+        <ul class="govuk-list govuk-list--bullet govuk-hint">
+          <li>Can view and submit logs</li>
+          <li>Can manage other users</li>
+        </ul>
+      {% endset %}
+
+      {{ govukRadios(decorate({
+        fieldset: {
+          legend: {
+            html: macro.heading(title, user.name)
+          }
+        },
+        items: [{
+          value: "provider",
+          text: "Data provider",
+          label: {
+            classes: "govuk-label--s"
+          },
+          hint: {
+            html: dataProviderPermissionsHintHtml
+          }
+        }, {
+          value: "coordinator",
+          text: "Data coordinator",
+          label: {
+            classes: "govuk-label--s"
+          },
+          hint: {
+            html: dataCoordinatorPermissionsHintHtml
+          }
+        }]
+      }, ["users", user.id, "role"])) }}
+
+      {{ govukButton({
+        text: buttonText
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/users/user.njk
+++ b/app/views/users/user.njk
@@ -1,0 +1,84 @@
+{% extends "base.njk" %}
+
+{% import "macros.njk" as macro %}
+
+{% set title = user.name or user.email %}
+{% set referrer = "/account" %}
+
+{% block pageNavigation %}
+  {{ govukBreadcrumbs({
+    items: [{
+      href: "/users",
+      text: "Users"
+    }, {
+      text: title
+    }]
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ macro.heading(title, 'Users') }}
+
+      {{ govukSummaryList({
+        rows: [{
+          key: {
+            text: "Name"
+          },
+          value: {
+            text: user.name
+          },
+          actions: {
+            items: [{
+              href: userPath + "/personal-details",
+              text: "Change",
+              visuallyHiddenText: "name"
+            }]
+          } if not user.deactivated
+        }, {
+          key: {
+            text: "Email address"
+          },
+          value: {
+            text: user.email | urlize | safe
+          },
+          actions: {
+            items: [{
+              href: userPath + "/personal-details",
+              text: "Change",
+              visuallyHiddenText: "email address"
+            }]
+          } if not user.deactivated
+        }, {
+          key: {
+            text: "Role"
+          },
+          value: {
+            text: "Data " + user.role
+          },
+          actions: {
+            items: [{
+              href: userPath + "/role",
+              text: "Change",
+              visuallyHiddenText: "role"
+            }]
+          } if not user.deactivated
+        }, {
+          key: {
+            text: "Last logged in"
+          },
+          value: {
+            html: macro.userLastActiveHtml(id, user)
+          }
+        } if not user.deactivated]
+      }) }}
+
+      {% if not user.deactivated %}
+        <p><a href="{{ userPath }}/deactivate">Deactivate user</a></p>
+      {% else %}
+        <p class="govuk-body app-!-colour-muted">This user has been deactivated.</p>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Initial flows for adding and deactivating users. These flows don’t consider how organisations figure into user and account management, but that will come later.

## Example users

Logging in with the following accounts will similate different access permissions:

* delia.cross@example.gov.uk - Data coordinator
* daisy.perkins@example.gov.uk - Data provider

As it stands:

* **Data coordinators** can see all users, invite new users, and deactivate users. They can also edit their own email address (as well as their name and password).
* **Data providers** can only edit their name and password.

This is not set in stone, but is a starting point for some role based permissions.

## Managing users

Only data coordinators see the ‘Users’ link in the header.

### Users

Lists all users, with their name, email, role and when they last logged in.

![users](https://user-images.githubusercontent.com/813383/139304083-e87d6703-4eae-45d9-9eda-281bc667e4ea.png)

## User

### User profile

![user](https://user-images.githubusercontent.com/813383/139304663-d45aa2b2-862f-4b52-bc98-1a9a01aeb30c.png)

### Change a user’s personal details

![user-details](https://user-images.githubusercontent.com/813383/139304643-7bd5d20a-bd75-427d-9e90-d48d61ff5e64.png)

### Change a user’s role

![user-role](https://user-images.githubusercontent.com/813383/139304655-1159b85c-b4d4-4d3f-a539-01ba4f8dfccf.png)

## Inviting a new user

### Ask for name and email

![add-user-personal-details](https://user-images.githubusercontent.com/813383/139307037-bd61f868-36e2-4a63-95b1-a538639753cd.png)

### Choose a role

![add-user-role](https://user-images.githubusercontent.com/813383/139307081-235c7177-5e7b-4964-9a3b-f615c4394fde.png)

### Success notification

![add-user-success](https://user-images.githubusercontent.com/813383/139304226-8f836f99-d482-45a4-8600-a878d22811c5.png)

An email (not shown) will be sent to a user to invite them to sign up. See this page: https://core-beta-prototype.herokuapp.com/account/create-account

We could also offer the ability to resend the invitation email.

## Deactivate a user

Question: do we want to deactivate users, delete them, or offer both options? For now, just offering ability to deactivate.

From the user profile page, click ‘Deactivate user’ link.

### Confirm deactivation

![user-deactivate-confirm](https://user-images.githubusercontent.com/813383/139304885-9bd5290b-23cb-49f2-b865-9e5d4ad9d5a3.png)

### Success notification

![user-deactivate-success](https://user-images.githubusercontent.com/813383/139304894-35bcd82f-06f8-4b20-a9dc-c3b536eff0a3.png)

### Deactivated user profile

You can’t change the details of a deactivated user.

![user-deactivated](https://user-images.githubusercontent.com/813383/139304903-3904868c-c048-4fb6-a08b-655a86947bf9.png)